### PR TITLE
Use Chrome commands for capturing media keys.

### DIFF
--- a/src/background/background.haml
+++ b/src/background/background.haml
@@ -7,6 +7,6 @@
     %script{:src => "lastfm/lastfm.api.md5.js"}
     %script{:src => "lastfm/lastfm.api.js"}
     %script{:src => "scrobbler.js"}
-    %script{:src => "media_key_support_npapi.js"}
+    %script{:src => "media_key_support_commands.js"}
     - # Todo: add sway favoriting support back here
   %body

--- a/src/background/media_key_support_commands.coffee
+++ b/src/background/media_key_support_commands.coffee
@@ -1,0 +1,12 @@
+document.addEventListener 'DOMContentLoaded', ->
+  chrome.commands.onCommand.addListener (command) ->
+    console.log 'Command: ', command
+    if command is 'pause'
+      sendAction 'pause'
+    else if command is 'next'
+      sendAction 'next'
+    else if command is 'previous'
+      sendAction 'previous'
+
+# They only need to be registered once.
+window.useMediaKeys = -> null

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -24,6 +24,29 @@
   "background": {
     "page":"background/background.html"
   },
+  "commands": {
+    "pause": {
+      "suggested_key": {
+        "default": "MediaPlayPause"
+      },
+      "description": "Play/Pause",
+      "global": true
+    },
+    "next": {
+      "suggested_key": {
+        "default": "MediaNextTrack"
+      },
+      "description": "Next Song",
+      "global": true
+    },
+    "previous": {
+      "suggested_key": {
+        "default": "MediaPrevTrack"
+      },
+      "description": "Previous Song",
+      "global": true
+    }
+  },
   "content_scripts": [
     {
       "matches": ["*://*.youtube.com/*"],


### PR DESCRIPTION
Now supports global scope and so works even when Chrome is in the background.

https://developer.chrome.com/extensions/commands

Not sure this does exactly what you're trying to achieve, though, because it won't yield control to other applications like SPMediaKeyTap will.

I made this change because I'm running chrome dev channel on os x, npapi stopped working (whether due to deprecation or because the binary isn't fat and I'm on 64-bit chrome now), and I couldn't get the native version working. This works great with the aforementioned caveat.
