### PR TITLE
Return Yandex.Music

### DIFF
--- a/src/background/mappings.coffee
+++ b/src/background/mappings.coffee
@@ -96,6 +96,7 @@ mapping =
   'vk': 'VkController.js'
   'wearehunted': 'WeAreHuntedController.js'
   'y.qq': 'QQMusicController.js'
+  'music.yandex': 'YandexMusicController.js'
   'radio.yandex': 'YandexRadioController.js'
   'youtube': 'YoutubeController.js'
   'albumkings': 'AlbumKingsController.js'

--- a/src/controllers/YandexMusicController.js
+++ b/src/controllers/YandexMusicController.js
@@ -1,0 +1,26 @@
+controller = new BasicController({
+    supports: {
+        playpause: true,
+        next: true,
+        previous: true,
+        favorite: true
+    },
+    playPauseSelector: '.player-controls__btn_play',
+    previousSelector: '.player-controls__btn_prev',
+    nextSelector: '.player-controls__btn_next',
+    titleSelector: '.player-controls .track__title',
+    artistSelector: '.player-controls .track__artists',
+    playStateSelector: '.player-controls__btn_play',
+    playStateClass: 'player-controls__btn_pause',
+    artworkImageSelector: '.player-controls .album-cover',
+    favoriteSelector: '.player-controls .like',
+    isFavoriteSelector: '.player-controls .like_on'
+});
+ 
+controller.override('getAlbumArt', function() {
+    var img = document.querySelector(this.artworkImageSelector);
+    if (img) {
+        return img.src.replace('40x40', '150x150');
+    }
+    return undefined
+});


### PR DESCRIPTION
Recently Yandex.Music worked through the Sway.fm API, but now either Yandex has removed the support, either something happened to the API, so the integration isn't working any more.
This controller has previously been removed from the project because there was no one to support it due to Yandex.Music working only in Russia and a few other countries. I'm from Russia, so I think I can keep the controller up to date.