### PR TITLE
Add (optional) notifications

### DIFF
--- a/src/background/background.coffee
+++ b/src/background/background.coffee
@@ -61,11 +61,9 @@ window.addStateListener = (l) ->
   stateListeners.push l
 
 newState = (state) ->
-  if not wasPlaying and state.playing
-    useMediaKeys()
+  useMediaKeys() if not wasPlaying and state.playing
   wasPlaying = state.playing
-  for listener in stateListeners
-    listener(state)
+  listener(state) for listener in stateListeners
 
 handleRequestFromContentScript = (request, sender, sendResponse) ->
   console.log("REQ", request)

--- a/src/background/background.haml
+++ b/src/background/background.haml
@@ -7,6 +7,7 @@
     %script{:src => "lastfm/lastfm.api.md5.js"}
     %script{:src => "lastfm/lastfm.api.js"}
     %script{:src => "scrobbler.js"}
+    %script{:src => "notifications.js"}
     %script{:src => "media_key_support_commands.js"}
     %script{:src => "track.js"}
     - # Todo: add sway favoriting support back here

--- a/src/background/notifications.coffee
+++ b/src/background/notifications.coffee
@@ -1,0 +1,52 @@
+NOTIFY_DELAY = 2000
+NOTIFY_IDENT = 'song-change'
+STORAGE_PATH = 'notifications-enabled'
+
+window.setNotificationsEnabled = (enabled) ->
+  localStorage.setItem(STORAGE_PATH, enabled)
+
+window.isNotificationsEnabled = ->
+  data = localStorage.getItem(STORAGE_PATH)
+  data && JSON.parse(data)
+
+# Main notification handler
+window.notifyJob =
+  schedule: (id) ->
+    notifyCallback = -> 
+      window.notifyJob.sent = true
+      sendAction('getState')
+    
+    window.notifyJob.reset()
+    window.notifyJob.id = id
+    window.notifyJob.callbackId = setTimeout notifyCallback, NOTIFY_DELAY
+
+  flush: (options) ->
+    window.notifyJob.reset()
+    chrome.notifications.create NOTIFY_IDENT, options
+  
+  reset: ->
+    clearTimeout(window.notifyJob.callbackId) if window.notifyJob.callbackId
+    window.notifyJob.sent = false
+    window.notifyJob.callbackId = undefined
+    window.notifyJob.playing = false
+
+# Sends chrome notifications, but with delay 2 seconds to load
+# proper album art
+addStateListener (state) ->
+  if isNotificationsEnabled()
+    id = state.artist + state.title
+    
+    if (id isnt window.notifyJob.id) or (not window.notifyJob.playing and state.playing)
+      # Schedule next notification
+      window.notifyJob.schedule id
+    else if window.notifyJob.sent
+      # 2 seconds passed, show scheduled notification
+      window.notifyJob.flush
+        type: 'basic',
+        iconUrl: state.albumArt,
+        title: state.title,
+        message: state.artist
+  
+  # Save playing state in case of play/pause events
+  window.notifyJob.playing = state.playing
+

--- a/src/options/options.coffee
+++ b/src/options/options.coffee
@@ -46,8 +46,13 @@ allSet = () ->
   document.querySelector(".alert").classList.add("success")
 
 youtubeBox = document.querySelector("#ignore-youtube-checkbox")
-if JSON.parse(localStorage.getItem("ignore-youtube"))
-  youtubeBox.checked = true
+youtubeBox.checked = true if JSON.parse(localStorage.getItem("ignore-youtube"))
 youtubeBox.addEventListener "change", () ->
   console.log("CHANGE", youtubeBox.checked)
   localStorage.setItem("ignore-youtube", JSON.parse(youtubeBox.checked))
+
+notificationsBox = document.querySelector("#notifications-checkbox")
+notificationsBox.checked = bkg.isNotificationsEnabled()
+notificationsBox.addEventListener "change", () ->
+  console.log("CHANGE", notificationsBox.checked)
+  bkg.setNotificationsEnabled(notificationsBox.checked)

--- a/src/options/options.haml
+++ b/src/options/options.haml
@@ -36,6 +36,13 @@
           %input#ignore-youtube-checkbox{:type => "checkbox"}
         .section-content
           Check this if you'd like to play youtube videos while listening to music, and don't want to auto-pause the music when you start playing a youtube video.
+      
+      .section
+        .section-title
+          Enable notifications
+          %input#notifications-checkbox{:type => "checkbox"}
+        .section-content
+          Check this if you'd like to see push notifications whenever current song changes.
 
       .section{:style => "display:none"}
         .section-title


### PR DESCRIPTION
Add chrome notifications and new flag to options page
that enables/disables them (disabled by default).
Fixes #32

Notifications have this configuration:

```
{
      iconUrl: <album-art>,
      title: <song-title>,
      message: <song-artist>
}
```