### PR TITLE
Prevent ReferenceError on variable definition check

### DIFF
--- a/src/content_scripts/content.coffee
+++ b/src/content_scripts/content.coffee
@@ -34,7 +34,7 @@ window.isVisible = (el) ->
   return true;
 init = () ->
   success = false
-  if controller
+  if controller?
     success = controller.init();
     if success
       chrome.extension.sendRequest({action: "controller_loaded", host:window.location.host}, noop)


### PR DESCRIPTION
Fixed and error logged in Chrome console when this plugin was enabled. Only happens when opening local HTML (`file:///` protocol) . Should be easier for developers to work while listening to music now :)

