### PR TITLE
Add marquee scrolling when title or artist name is too long

### DIFF
--- a/src/popup/popup.coffee
+++ b/src/popup/popup.coffee
@@ -20,6 +20,7 @@ document.addEventListener "keydown", (e) ->
     sendRequest "next"
 
 setClass = (el, className, show) ->
+  if !el then return
   if show then el.classList.add(className) else el.classList.remove(className)
 
 shouldShow = (qs, should) ->
@@ -30,6 +31,9 @@ updateUI = (uiState) ->
   $("#song-name").textContent = uiState.title
   $("#artist-name").textContent = uiState.artist
   $("#album-art").src = uiState.albumArt || "data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw=="
+
+  setClass $("#song-name"), "marquee", $("#song-name").clientWidth > $("#song-name").parentNode.clientWidth
+  setClass $("#artist-name"), "marquee", $("#artist-name").clientWidth > $("#artist-name").parentNode.clientWidth
 
   setClass document.body, "playing", uiState.playing
   setClass $("#thumbs-up"), "toggled", uiState.thumbsUp

--- a/src/popup/popup.coffee
+++ b/src/popup/popup.coffee
@@ -71,6 +71,8 @@ load = () ->
   bindClickToAction "#next", "next"
   bindClickToAction "#song-details", "focus"
   bindClickToAction "#album-art", "focus"
+  document.body.classList.remove("loading")
+  
 document.addEventListener "DOMContentLoaded", load, false
 
 convertCTAToShare = () ->

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -27,6 +27,18 @@ body {
     font-weight: 200;
 }
 
+.loading #playing-container {
+  display: none;
+}
+
+#loading {
+  display: none;
+}
+
+.loading #loading {
+  display: block;
+}
+
 #topbar {
   height: 10px;
   background: #00a0e0;

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -106,7 +106,15 @@ body.playing #play-pause {
 
 #song-details {
   -webkit-box-flex: 1;
-  padding-left: 10px;
+  margin-left: 10px;
+  position: relative;
+  overflow: hidden;
+  height: 60px;
+}
+
+#song-details>.marquee{
+  transform: translateX(100%);
+  animation: marquee 15s linear infinite;
 }
 
 #artist-name {
@@ -115,6 +123,8 @@ body.playing #play-pause {
   white-space: nowrap;
   font-size: 14pt;
   opacity: 0.7;
+  top: 24px;
+  position: absolute;
 }
 
 #song-name {
@@ -122,6 +132,7 @@ body.playing #play-pause {
   text-overflow: ellipsis;
   white-space: nowrap;
   font-size: 16pt;
+  position: absolute;
 }
 
 #art-holder {
@@ -194,3 +205,14 @@ a.donate {
   border: 0;
   text-decoration: none;
 }
+
+@keyframes marquee {
+  0% {
+    transform: translateX(220px);
+  }  
+  100% {
+    transform: translateX(-100%);
+  }
+}
+
+

--- a/src/popup/popup.haml
+++ b/src/popup/popup.haml
@@ -3,7 +3,7 @@
   %head
     %link{:href => "http://fonts.googleapis.com/css?family=Source+Sans+Pro:200,300,400,700", :rel => "stylesheet", :type => "text/css"}
     %link{:href => "popup.css", :rel => "stylesheet", :type => "text/css"}
-  %body
+  %body.loading
     #topbar
     #playing-container
       #header.no-music
@@ -31,5 +31,8 @@
           and
           %a#share-link
             Share with friends!
+    #loading
+      %p
+        Loading...
     %script{:src => "popup.js"}
     -# %script{:src => "track.js", :async => true}


### PR DESCRIPTION
When the song title or artist is too long to fit in the details popup, it scrolls like a marquee.

Note that the animation is smooth, and the jumpiness is simply the gif recording.

### Showcase
![mobile header display bug fixed](https://cloud.githubusercontent.com/assets/35118/20799411/1e8f5a98-b7b0-11e6-9e25-3b64c54d63e2.gif)
