### PR TITLE
Add support for beta.mixcloud.com

### DIFF
--- a/src/controllers/MixcloudController.js
+++ b/src/controllers/MixcloudController.js
@@ -34,8 +34,9 @@ const config = [
 controller = new BasicController(config);
 
 controller.override('getAlbumArt', function(_super) {
-  var art = _super();
-  return art && art.replace(/\/60\//g, '\/300\/');
+  let art = _super();
+  return art && art.replace(/\/60\//g, '\/300\/')
+                   .replace(/\/60x60\//g, '\/300x300\/');
 });
 
 const CUSTOM_EVENT_TYPE = 'mxswayEvent';

--- a/src/controllers/MixcloudController.js
+++ b/src/controllers/MixcloudController.js
@@ -1,16 +1,37 @@
-controller = new BasicController({
-  supports: {
-    playpause: true,
-    previous: true,
-    next: true
+var isBeta = !!document.querySelector('.mz-player-control');
+
+var config = [
+  {
+    test: () => !isBeta,
+    supports: {
+      playpause: true,
+      previous: true,
+      next: true
+    },
+    playStateSelector: '.player-control',
+    playStateClass: 'pause-state',
+    playPauseSelector: '.player-control',
+    titleSelector: '.player-cloudcast-title',
+    artistSelector: '.player-cloudcast-author-link',
+    artworkImageSelector: '.player-cloudcast-image img'
   },
-  playStateSelector: '.player-control',
-  playStateClass: 'pause-state',
-  playPauseSelector: '.player-control',
-  titleSelector: '.player-cloudcast-title',
-  artistSelector: '.player-cloudcast-author-link',
-  artworkImageSelector: '.player-cloudcast-image img',
-});
+  {
+    test: () => isBeta,
+    supports: {
+      playpause: true,
+      previous: true,
+      next: true
+    },
+    playStateSelector: '.mz-player-control',
+    playStateClass: 'mz-pause-state',
+    playPauseSelector: '.mz-player-control',
+    titleSelector: '.mz-player-cloudcast-title',
+    artistSelector: '.mz-player-cloudcast-author-link',
+    artworkImageSelector: '.mz-player-cloudcast-image img'
+  }
+];
+
+controller = new BasicController(config);
 
 controller.override('getAlbumArt', function(_super) {
   var art = _super();
@@ -34,6 +55,7 @@ controller.override('previousSong', function() {
 var actualCode = `
 window.mxsway = {
   // const
+  SCRUBBER_SELECTOR: '.${isBeta ? 'mz-' : ''}player-scrubber',
   SKIP_TIME: 60, // 1 minute
 
   // private vars
@@ -51,7 +73,7 @@ window.mxsway = {
   moveTo: function(delta) {
     // micro-singleton
     if (!mxsway.entity) {
-      mxsway.entity = $('.player-scrubber').scope();
+      mxsway.entity = $(mxsway.SCRUBBER_SELECTOR).scope();
     }
 
     var entity = mxsway.entity;


### PR DESCRIPTION
As the title states. I could have sworn I saw an issue about this a few days ago, but I can't find it now. Anyway, Mixcloud is running a beta, and they've changed the selectors a bit. This PR adds support for the beta site/player to the Mixcloud controller. Of course, since it's a beta, the controller may need to be updated in the future as Mixcloud's engineers change things, but at least it works now if you've opted in.

Note that to get this to work on my machine I needed to apply the changes made in #105. I didn't want to wait until that one is merged before making this PR though, so here it is, based on the latest `master`. If #105 gets merged before this one, I will of course happily rebase this PR.