### PR TITLE
Use "positive" test functions in config

### DIFF
--- a/src/controllers/MixcloudController.js
+++ b/src/controllers/MixcloudController.js
@@ -1,8 +1,9 @@
+const isOldPlayer = () => !!document.querySelector('.player-control');
 const isNewPlayer = () => !!document.querySelector('.mz-player-control');
 
 const config = [
   {
-    test: () => !isNewPlayer(),
+    test: isOldPlayer,
     supports: {
       playpause: true,
       previous: true,
@@ -16,7 +17,7 @@ const config = [
     artworkImageSelector: '.player-cloudcast-image img'
   },
   {
-    test: () => isNewPlayer(),
+    test: isNewPlayer,
     supports: {
       playpause: true,
       previous: true,


### PR DESCRIPTION
As suggested by @msfeldstein in #106. "Positive" test functions that don't rely on an element *not* being present are more robust (e.g. if the site switches to rendering the player after the initial page load). Not strictly necessary here, and we're not using the `test` functionality like that (yet), but then again, no reason to give a bad example!