### PR TITLE
Fixes for `open.spotify.com`

### DIFF
--- a/src/controllers/SpotifyController.js
+++ b/src/controllers/SpotifyController.js
@@ -34,6 +34,14 @@ if (window.location.hostname === 'open.spotify.com') {
 
     return titleNodes.pop().textContent
   })
+
+  // There may be multiple artists linked per title
+  controller.override('getArtist', function () {
+    // Spread into array because `map` does not work reliably over NodeList.
+    const artistNodes = [...this.doc().querySelectorAll(config.artistSelector)]
+
+    return artistNodes.map(artist => artist.textContent).join(', ');
+  })
 } else {
   if (document.querySelector('#app-player')) { // Old Player
     config.artworkImageSelector = '#cover-art .sp-image-img';

--- a/src/controllers/SpotifyController.js
+++ b/src/controllers/SpotifyController.js
@@ -27,6 +27,13 @@ if (window.location.hostname === 'open.spotify.com') {
   controller.override('isPlaying', function () {
     return this.doc().querySelector('.now-playing-bar .spoticon-pause-32');
   })
+
+  // The album image also links to `/album/...`. Take last link for the title
+  controller.override('getTitle', function () {
+    const titleNodes = [...this.doc().querySelectorAll('.now-playing-bar [href^="/album"]')]
+
+    return titleNodes.pop().textContent
+  })
 } else {
   if (document.querySelector('#app-player')) { // Old Player
     config.artworkImageSelector = '#cover-art .sp-image-img';


### PR DESCRIPTION
This PR includes following 2 fixes:

1. Contrary to playlists, on _album pages_ the selector `.now-playing-bar [href^="/album"]` for the title would return two results: 1. The album art (picture) and 2. the title text. 
On _playlist pages_ the first result is the title text. To fix this, all elements with this selector are selected (with `document.querySelectorAll`) and the last result is taken as title text.
2. With the new Spotify version there can be more than one artist per track. These are now concatenated with a comma separated list

Before & after:
<img width="399" alt="cmk_before" src="https://cloud.githubusercontent.com/assets/571589/23786555/031e78e6-056e-11e7-8454-7da4faf829c8.png">
<img width="398" alt="cmk_after" src="https://cloud.githubusercontent.com/assets/571589/23786567/08a578e6-056e-11e7-8259-d62787aa9992.png">

([Example album](https://open.spotify.com/album/4IWLXhyvj0rH2cm5VwuuW9))