### PR TITLE
Load BasicController specifically before custom controller.

### DIFF
--- a/src/background/background.coffee
+++ b/src/background/background.coffee
@@ -77,6 +77,7 @@ handleRequestFromContentScript = (request, sender, sendResponse) ->
     if not script then return
     if script.indexOf('Shim') == -1
       trackController(request.host)
+    chrome.tabs.executeScript sender.tab.id, {file: 'controllers/BasicController.js'}
     chrome.tabs.executeScript(sender.tab.id, {file: script})
     if request.host.indexOf("monstercat") > -1
       chrome.tabs.executeScript(sender.tab.id, {file: 'controllers/ShimController.js'})

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -70,7 +70,7 @@
     {
       "matches": ["<all_urls>"],
       "patterns": ["http://*/*", "https://*/*"],
-      "js": ["content_scripts/content.js", "controllers/BasicController.js"],
+      "js": ["content_scripts/content.js"],
      	"run_at": "document_idle"
     }
   ],


### PR DESCRIPTION
This loads the `BasicController` class directly before loading the custom controller. Fixes #25 for me, i.e. after reloading the extension everything still works without having to reload the page afterwards. (But the previous MutationObserver is still there and fires events into the void producing error messages in the console. However, this doesn't seem to be a problem and is gone when you reload the web page.)