### PR TITLE
Change Spotify selectors

### DIFF
--- a/src/controllers/SpotifyController.js
+++ b/src/controllers/SpotifyController.js
@@ -13,19 +13,24 @@ const config = {
 // New version of spotify
 if (window.location.hostname === 'open.spotify.com') {
   delete config.playStateClass;
-  config.playStateSelector = '.now-playing-bar .control-button[class*="spoticon-play"]';
-  config.playSelector = '.now-playing-bar .control-button[class*="spoticon-play"]';
-  config.pauseSelector = '.now-playing-bar .control-button[class*="spoticon-pause"]';
+
+  const i18nLabels = JSON.parse(
+    document.querySelector('#jsonTranslations').innerHTML
+  );
+
+  config.playStateSelector = `.now-playing-bar .player-controls__buttons [aria-label="${i18nLabels['playback-control.play']}"]`;
+  config.playSelector = `.now-playing-bar .player-controls__buttons [aria-label="${i18nLabels['playback-control.play']}"]`;
+  config.pauseSelector = `.now-playing-bar .player-controls__buttons [aria-label="${i18nLabels['playback-control.pause']}"]`;
   config.artworkImageSelector = '.now-playing-bar .cover-art-image';
   config.artistSelector = '.now-playing-bar [href^="/artist"]';
   config.titleSelector = '.now-playing-bar [href^="/album"]';
-  config.nextSelector = '.now-playing-bar .control-button[class*="spoticon-skip-forward"]';
-  config.previousSelector = '.now-playing-bar .control-button[class*="spoticon-skip-back"]';
+  config.nextSelector = `.now-playing-bar .player-controls__buttons [aria-label="${i18nLabels['playback-control.skip-forward']}"]`;
+  config.previousSelector = `.now-playing-bar .player-controls__buttons [aria-label="${i18nLabels['playback-control.skip-back']}"]`;
 
   controller = new BasicController(config);
 
   controller.override('isPlaying', function () {
-    return this.doc().querySelector('.now-playing-bar .control-button[class*="spoticon-pause"]');
+    return !!this.doc().querySelector(config.pauseSelector);
   })
 
   // The album image also links to `/album/...`. Take last link for the title


### PR DESCRIPTION
I am still using this great extension to this day 🙌

Seemingly Spotify just recently changed their tags and classes. The class names seem to be generated now and follow no deterministic rule.
So I found that they put an `aria-label` attribute on their buttons with the according action in the specific language you are viewing it with.

They're exposing their translations in JSON though, so I was able to map the buttons to the individual action.

Cheers